### PR TITLE
:bug: Fix plugin crashes on missing nested path

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -61,7 +61,7 @@ function findMissingsFromLocaleMessages (localeMessages, key) {
     let last = localeMessage.messages
     let i = 0
     while (i < length) {
-      const value = last[paths[i]]
+      const value = last && last[paths[i]]
       if (value === undefined) {
         missings.push({
           message: `'${key}' does not exist`

--- a/tests/lib/rules/no-missing-keys.js
+++ b/tests/lib/rules/no-missing-keys.js
@@ -108,5 +108,15 @@ tester.run('no-missing-keys', rule, {
     errors: [
       `You need to 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`
     ]
+  }, {
+    // nested basic
+    settings,
+    code: `$t('missing.path')`,
+    errors: [
+      `'missing.path' does not exist`,
+      `'missing.path' does not exist`,
+      `'missing.path' does not exist`,
+      `'missing.path' does not exist`
+    ]
   }]
 })


### PR DESCRIPTION
Currently the plugin crashes if a nested path does not exist
Not sure why did it output double the error vs non-nested path though